### PR TITLE
fix: CPU compatibility, missing deps, and deprecated AMP API

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,3 +19,4 @@ dependencies:
       - h5py
       - plyfile
       - trimesh
+      - matplotlib

--- a/inference_gencad.py
+++ b/inference_gencad.py
@@ -128,6 +128,14 @@ def vec_to_CAD(cad_vec):
         print('cannot create CAD')
 
 
+def resolve_input_images(image_path):
+    if os.path.isdir(image_path):
+        return glob.glob(os.path.join(image_path, "*.png"))
+    if os.path.isfile(image_path):
+        return [image_path]
+    raise FileNotFoundError(f"Input path does not exist: {image_path}")
+
+
 def main(img_dir, export_stl=False, export_img=False):
     """
     
@@ -151,10 +159,11 @@ def main(img_dir, export_stl=False, export_img=False):
 
     # device
 
-    device_num = 0
-    device = torch.device(f"cuda:{device_num}")
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     phase = "test"
     batch_size = 64
+
+    print(f'# # Running inference on {device}')
 
     ########################################
     ########################################
@@ -211,7 +220,7 @@ def main(img_dir, export_stl=False, export_img=False):
 
     cad_decoder = VanillaCADTransformer(config).to(config.device) 
 
-    cad_ckpt = torch.load(cad_ckpt_path)
+    cad_ckpt = torch.load(cad_ckpt_path, map_location="cpu")
     cad_decoder.load_state_dict(cad_ckpt['model_state_dict'])
     cad_decoder.eval()
 
@@ -219,7 +228,10 @@ def main(img_dir, export_stl=False, export_img=False):
 
     ################# generate images #############
 
-    image_files = glob.glob(f"{img_dir}/*.png")
+    image_files = resolve_input_images(img_dir)
+
+    if not image_files:
+        raise FileNotFoundError(f"No PNG images found for input: {img_dir}")
 
     for img_path in tqdm(image_files):
         img = process_image(img_path).to(device)
@@ -253,19 +265,21 @@ def main(img_dir, export_stl=False, export_img=False):
             shape = vec_to_CAD(cad_vec=cad_vec)
 
             if export_img: 
-                img_name = img_path.split('.')[0].split('/')[-1]
-                os.makedirs(os.path.join(img_dir, "generated_images"), exist_ok=True) 
-                img_export_path = img_dir + "/generated_images/" + f"{img_name}.png"
+                input_root = img_dir if os.path.isdir(img_dir) else os.path.dirname(img_path)
+                img_name = os.path.splitext(os.path.basename(img_path))[0]
+                os.makedirs(os.path.join(input_root, "generated_images"), exist_ok=True) 
+                img_export_path = os.path.join(input_root, "generated_images", f"{img_name}.png")
                 save_view(shape, view_type='iso', save_path=img_export_path)
 
 
             if export_stl:
-                img_name = img_path.split('.')[0].split('/')[-1]
-                os.makedirs(os.path.join(img_dir, "stls"), exist_ok=True) 
-                export_path = img_dir + "/stls/" + f"{img_name}.stl"
+                input_root = img_dir if os.path.isdir(img_dir) else os.path.dirname(img_path)
+                img_name = os.path.splitext(os.path.basename(img_path))[0]
+                os.makedirs(os.path.join(input_root, "stls"), exist_ok=True) 
+                export_path = os.path.join(input_root, "stls", f"{img_name}.stl")
                 write_stl_file(shape, export_path, mode="binary", linear_deflection=0.5, angular_deflection=0.3,)
-        except:
-            print("cannot find EOS") 
+        except Exception as exc:
+            print(f"inference failed for {img_path}: {exc}") 
 
 
 if __name__ == "__main__":

--- a/model/cond_ldm.py
+++ b/model/cond_ldm.py
@@ -8,7 +8,6 @@ from multiprocessing import cpu_count
 import torch
 from torch import nn, einsum, Tensor
 import torch.nn.functional as F
-from torch.cuda.amp import autocast, GradScaler
 from torch.optim import Adam
 from torch.utils.data import Dataset, DataLoader
 
@@ -365,7 +364,7 @@ class GaussianDiffusion1D(nn.Module):
 
         return img
 
-    @autocast(enabled = False)
+    @torch.amp.autocast("cuda", enabled = False)
     def q_sample(self, x_start, t, noise=None):
         noise = default(noise, lambda: torch.randn_like(x_start))
 
@@ -488,7 +487,7 @@ class Trainer1D(object):
 
         # Mixed Precision Setup
         self.amp = amp
-        self.scaler = GradScaler() if self.amp else None
+        self.scaler = torch.amp.GradScaler("cuda", enabled = self.amp) if self.amp else None
 
 
     def _get_data(self, latent_data, gt=False):        
@@ -551,7 +550,7 @@ class Trainer1D(object):
                     cad_emb, image_emb = batch[0].to(self.device), batch[1].to(self.device)
 
                     if self.amp:
-                        with autocast():
+                        with torch.amp.autocast("cuda", enabled = self.amp):
                             loss = self.model(cad_emb, cond=image_emb)
                             loss = loss / self.gradient_accumulate_every
                             total_loss += loss.item()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ einops
 h5py
 plyfile
 trimesh
+matplotlib

--- a/trainer/diffusion_prior_trainer.py
+++ b/trainer/diffusion_prior_trainer.py
@@ -74,7 +74,7 @@ class Trainer1D(object):
 
         # Mixed Precision Setup
         self.amp = amp
-        self.scaler = GradScaler() if self.amp else None
+        self.scaler = torch.amp.GradScaler("cuda", enabled = self.amp) if self.amp else None
 
 
     def _get_data(self, latent_data, gt=False):        
@@ -137,7 +137,7 @@ class Trainer1D(object):
                     cad_emb, image_emb = batch[0].to(self.device), batch[1].to(self.device)
 
                     if self.amp:
-                        with autocast():
+                        with torch.amp.autocast("cuda", enabled = self.amp):
                             loss = self.model(cad_emb, cond=image_emb)
                             loss = loss / self.gradient_accumulate_every
                             total_loss += loss.item()

--- a/trainer/ldm_trainer.py
+++ b/trainer/ldm_trainer.py
@@ -11,7 +11,6 @@ from collections import namedtuple
 import torch 
 from torch import nn, einsum, Tensor
 import torch.nn.functional as F
-from torch.cuda.amp import autocast, GradScaler
 from torch.utils.data import DataLoader
 from torch.optim import Adam
 from multiprocessing import cpu_count
@@ -136,7 +135,7 @@ class Trainer1D(object):
 
         # Mixed Precision Setup
         self.amp = amp
-        self.scaler = GradScaler() if self.amp else None
+        self.scaler = torch.amp.GradScaler("cuda", enabled = self.amp) if self.amp else None
 
 
     def _get_data(self, latent_data, gt=False):        
@@ -199,7 +198,7 @@ class Trainer1D(object):
                     cad_emb, image_emb = batch[0].to(self.device), batch[1].to(self.device)
 
                     if self.amp:
-                        with autocast():
+                        with torch.amp.autocast("cuda", enabled = self.amp):
                             loss = self.model(cad_emb, cond=image_emb)
                             loss = loss / self.gradient_accumulate_every
                             total_loss += loss.item()

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -109,7 +109,7 @@ def logits2vec(outputs, refill_pad=True, to_numpy=True, device=None):
         if device is None:
             mask = ~torch.tensor(CMD_ARGS_MASK).bool().cpu()[out_command.long()]
         else: 
-            mask = ~torch.tensor(CMD_ARGS_MASK).bool().cuda(device=device)[out_command.long()]
+            mask = ~torch.tensor(CMD_ARGS_MASK).bool().to(device)[out_command.long()]
 
         out_args[mask] = -1
 


### PR DESCRIPTION
- inference_gencad.py: auto-detect CPU when CUDA is unavailable instead of hardcoding cuda:0; accept single image file in addition to directory; load CAD checkpoint with map_location='cpu'; print export paths; improve exception messages
- utils/model_utils.py: replace .cuda(device=device) with .to(device) in logits2vec so inference works on CPU
- model/cond_ldm.py: replace deprecated torch.cuda.amp autocast/GradScaler with torch.amp equivalents
- trainer/ldm_trainer.py: same AMP deprecation fix
- trainer/diffusion_prior_trainer.py: same AMP deprecation fix
- requirements.txt: add matplotlib (was missing)
- environment.yml: add matplotlib to pip section (was missing)