### PR TITLE
docs: fix pretrained checkpoint path to model/ckpt/

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Download from [here](https://drive.google.com/drive/folders/1M0dPr5kILGY9HTRCHox
 
 ## 📦 Pretrained Models
 
-Download from [here](https://drive.google.com/drive/folders/1Ej7wdtlqT5P-SoUf3gsZXD8b78XqhiI5?usp=sharing) and place them in `data/ckpt/`.
+Download from [here](https://drive.google.com/drive/folders/1Ej7wdtlqT5P-SoUf3gsZXD8b78XqhiI5?usp=sharing) and place them in `model/ckpt/`.
 
 ---
 


### PR DESCRIPTION
## Summary
- README instructs users to place pretrained models in `data/ckpt/`, but `inference_gencad.py` actually loads them from `model/ckpt/` (see L143-145).
- Following the README as-is causes a `FileNotFoundError` on the first inference run.
- This one-line fix aligns the docs with the code.

## Test plan
- [ ] Download the pretrained checkpoints and place them in `model/ckpt/` as the updated README instructs.
- [ ] Run `python inference_gencad.py -image_path data/test_images -export_img` and confirm checkpoints load without `FileNotFoundError`.